### PR TITLE
Add snippet and tree viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,7 @@ Additional features include:
 - Dired icons via `all-the-icons-dired`
 - Open files externally through `dired-open`
 - TOML and JSON editing modes
+- Indentation guides via `highlight-indent-guides`
+- Snippet expansion powered by `yasnippet`
+- Project tree navigation with `neotree`
 

--- a/alter/key.el
+++ b/alter/key.el
@@ -32,6 +32,7 @@
 (global-set-key "\C-z\C-d" 'vc-root-diff)
 (global-set-key "\C-z\C-s" 'counsel-git-grep)
 (global-set-key "\C-z\C-a" 'counsel-ag)
+(global-set-key "\C-z\C-t" 'neotree-toggle)
 
 ;; ;;; moving key bindings
 (global-set-key "\C-e\C-c" 'shell)

--- a/alter/secondary.el
+++ b/alter/secondary.el
@@ -32,6 +32,14 @@
   :hook (prog-mode . rainbow-delimiters-mode))
 
 ;;; ---------------------------------------------------------------------------
+;;; indentation guides
+;;; ---------------------------------------------------------------------------
+(use-package highlight-indent-guides
+  :hook (prog-mode . highlight-indent-guides-mode)
+  :config
+  (setq highlight-indent-guides-method 'column))
+
+;;; ---------------------------------------------------------------------------
 ;;; icon fonts
 ;;; ---------------------------------------------------------------------------
 (use-package all-the-icons)
@@ -86,6 +94,20 @@
 (use-package vterm)
 
 ;;; ---------------------------------------------------------------------------
+;;; snippet expansion
+;;; ---------------------------------------------------------------------------
+(use-package yasnippet
+  :config
+  (yas-global-mode 1))
+
+;;; ---------------------------------------------------------------------------
+;;; project tree viewer
+;;; ---------------------------------------------------------------------------
+(use-package neotree
+  :config
+  (setq neo-theme 'icons))
+
+;;; ---------------------------------------------------------------------------
 ;;; Enhanced dired
 ;;; ---------------------------------------------------------------------------
 (use-package diredfl
@@ -97,8 +119,12 @@
 (use-package dired-open
   :after dired
   :custom
-  (dired-open-extensions '(("png" . "xdg-open")
-                           ("jpg" . "xdg-open"))))
+  (dired-open-extensions
+   (if (eq system-type 'darwin)
+       '(("png" . "open")
+         ("jpg" . "open"))
+     '(("png" . "xdg-open")
+       ("jpg" . "xdg-open")))))
 
 ;;;---------------------------------------------------------------------------
 ;;; provide

--- a/init.el
+++ b/init.el
@@ -38,7 +38,8 @@
  '(package-selected-packages
    '(duplicate-thing nix-ts-mode nixpkgs-fmt nix-mode evil magit wgrep use-package path-headerline-mode doom-modeline counsel company good-scroll avy org-bullets doom-themes all-the-icons
      comment-dwim-2 ibuffer-vc smartparens beacon super-save ace-window expand-region helpful vterm markdown-mode
-     diredfl all-the-icons-dired dired-open toml-mode json-mode)))
+    diredfl all-the-icons-dired dired-open toml-mode json-mode
+    highlight-indent-guides yasnippet neotree)))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
## Summary
- add indentation guides with `highlight-indent-guides`
- add snippet expansion via `yasnippet`
- add project tree viewer using `neotree`
- allow dired-open to use `open` on macOS
- update keybindings for neotree
- document new features

## Testing
- `emacs` was not available so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_686091ea05508329816d3a875c701372