### PR TITLE
Add treemacs project viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Additional features include:
 - TOML and JSON editing modes
 - Indentation guides via `highlight-indent-guides`
 - Snippet expansion powered by `yasnippet`
-- Project tree navigation with `neotree`
+- LSP integration via `lsp-mode` and `lsp-treemacs`
+- Project tree navigation with `treemacs`
 - Multi-cursor editing via `multiple-cursors`
 - Automatic environment handling with `envrc`
 - Code folding powered by `origami`

--- a/alter/key.el
+++ b/alter/key.el
@@ -32,7 +32,7 @@
 (global-set-key "\C-z\C-d" 'vc-root-diff)
 (global-set-key "\C-z\C-s" 'counsel-git-grep)
 (global-set-key "\C-z\C-a" 'counsel-ag)
-(global-set-key "\C-z\C-t" 'neotree-toggle)
+(global-set-key "\C-z\C-t" 'treemacs)
 
 ;; ;;; moving key bindings
 (global-set-key "\C-e\C-c" 'shell)

--- a/alter/secondary.el
+++ b/alter/secondary.el
@@ -115,9 +115,12 @@
 ;;; ---------------------------------------------------------------------------
 ;;; project tree viewer
 ;;; ---------------------------------------------------------------------------
-(use-package neotree
+(use-package treemacs
   :config
-  (setq neo-theme 'icons))
+  (setq treemacs-is-never-other-window t))
+
+(use-package lsp-treemacs
+  :after (lsp-mode treemacs))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Enhanced dired

--- a/alter/secondary.el
+++ b/alter/secondary.el
@@ -116,6 +116,7 @@
 ;;; project tree viewer
 ;;; ---------------------------------------------------------------------------
 (use-package treemacs
+  :ensure t
   :config
   (setq treemacs-is-never-other-window t))
 

--- a/init.el
+++ b/init.el
@@ -39,7 +39,7 @@
    '(duplicate-thing nix-ts-mode nixpkgs-fmt nix-mode evil magit wgrep use-package path-headerline-mode doom-modeline counsel company good-scroll avy org-bullets doom-themes all-the-icons
      comment-dwim-2 ibuffer-vc smartparens beacon super-save ace-window expand-region helpful vterm markdown-mode
     diredfl all-the-icons-dired dired-open toml-mode json-mode envrc
-    highlight-indent-guides yasnippet neotree popwin aggressive-indent multiple-cursors origami)))
+    highlight-indent-guides yasnippet treemacs lsp-treemacs popwin aggressive-indent multiple-cursors origami)))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
## Summary
- replace Neotree with Treemacs for project tree navigation
- update keybinding to open Treemacs
- integrate lsp-treemacs for LSP views
- document new Treemacs and LSP features

## Testing
- `emacs` not available in container; cannot run byte-compilation

------
https://chatgpt.com/codex/tasks/task_e_686a98192c288329a53c6700e49a043c